### PR TITLE
track engagement clicks

### DIFF
--- a/dist/index.d.mts
+++ b/dist/index.d.mts
@@ -1127,6 +1127,16 @@ declare class MantleClient {
         id: string;
     }): Promise<SuccessResponse | MantleError>;
     /**
+     * Track a CTA click on an engagement (notification, checklist, etc.) as a usage event
+     * @param params.id - The ID of the engagement that was clicked
+     * @param params.engagementType - The type of engagement (e.g. "notification", "checklist")
+     * @returns A promise that resolves to a success response or an error
+     */
+    trackEngagementCtaClick(params: {
+        id: string;
+        engagementType: "notification" | "checklist";
+    }): Promise<SuccessResponse | MantleError>;
+    /**
      * Update a notification to set the readAt and dismissedAt dates
      * @param params.id - The ID of the notification to update
      * @param params.readAt - The date the notification was read

--- a/dist/index.d.mts
+++ b/dist/index.d.mts
@@ -1127,12 +1127,14 @@ declare class MantleClient {
         id: string;
     }): Promise<SuccessResponse | MantleError>;
     /**
-     * Track a CTA click on a notification as a usage event
-     * @param params.id - The ID of the notification (Notify record) that was clicked
+     * Track a notification CTA as a usage event
+     * @param params.id - The ID of the notification (Notify record)
+     * @param params.type - The type of CTA interaction. Defaults to "trigger"
      * @returns A promise that resolves to a success response or an error
      */
-    trackNotificationCtaClick(params: {
+    trackNotificationCta(params: {
         id: string;
+        type?: "trigger" | "click";
     }): Promise<SuccessResponse | MantleError>;
     /**
      * Update a notification to set the readAt and dismissedAt dates

--- a/dist/index.d.mts
+++ b/dist/index.d.mts
@@ -1127,11 +1127,11 @@ declare class MantleClient {
         id: string;
     }): Promise<SuccessResponse | MantleError>;
     /**
-     * Track a CTA click on an engagement as a usage event
+     * Track a CTA click on a notification as a usage event
      * @param params.id - The ID of the notification (Notify record) that was clicked
      * @returns A promise that resolves to a success response or an error
      */
-    trackEngagementCtaClick(params: {
+    trackNotificationCtaClick(params: {
         id: string;
     }): Promise<SuccessResponse | MantleError>;
     /**

--- a/dist/index.d.mts
+++ b/dist/index.d.mts
@@ -1127,14 +1127,12 @@ declare class MantleClient {
         id: string;
     }): Promise<SuccessResponse | MantleError>;
     /**
-     * Track a CTA click on an engagement (notification, checklist, etc.) as a usage event
-     * @param params.id - The ID of the engagement that was clicked
-     * @param params.engagementType - The type of engagement (e.g. "notification", "checklist")
+     * Track a CTA click on an engagement as a usage event
+     * @param params.id - The ID of the notification (Notify record) that was clicked
      * @returns A promise that resolves to a success response or an error
      */
     trackEngagementCtaClick(params: {
         id: string;
-        engagementType: "notification" | "checklist";
     }): Promise<SuccessResponse | MantleError>;
     /**
      * Update a notification to set the readAt and dismissedAt dates

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1127,6 +1127,16 @@ declare class MantleClient {
         id: string;
     }): Promise<SuccessResponse | MantleError>;
     /**
+     * Track a CTA click on an engagement (notification, checklist, etc.) as a usage event
+     * @param params.id - The ID of the engagement that was clicked
+     * @param params.engagementType - The type of engagement (e.g. "notification", "checklist")
+     * @returns A promise that resolves to a success response or an error
+     */
+    trackEngagementCtaClick(params: {
+        id: string;
+        engagementType: "notification" | "checklist";
+    }): Promise<SuccessResponse | MantleError>;
+    /**
      * Update a notification to set the readAt and dismissedAt dates
      * @param params.id - The ID of the notification to update
      * @param params.readAt - The date the notification was read

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1127,12 +1127,14 @@ declare class MantleClient {
         id: string;
     }): Promise<SuccessResponse | MantleError>;
     /**
-     * Track a CTA click on a notification as a usage event
-     * @param params.id - The ID of the notification (Notify record) that was clicked
+     * Track a notification CTA as a usage event
+     * @param params.id - The ID of the notification (Notify record)
+     * @param params.type - The type of CTA interaction. Defaults to "trigger"
      * @returns A promise that resolves to a success response or an error
      */
-    trackNotificationCtaClick(params: {
+    trackNotificationCta(params: {
         id: string;
+        type?: "trigger" | "click";
     }): Promise<SuccessResponse | MantleError>;
     /**
      * Update a notification to set the readAt and dismissedAt dates

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1127,11 +1127,11 @@ declare class MantleClient {
         id: string;
     }): Promise<SuccessResponse | MantleError>;
     /**
-     * Track a CTA click on an engagement as a usage event
+     * Track a CTA click on a notification as a usage event
      * @param params.id - The ID of the notification (Notify record) that was clicked
      * @returns A promise that resolves to a success response or an error
      */
-    trackEngagementCtaClick(params: {
+    trackNotificationCtaClick(params: {
         id: string;
     }): Promise<SuccessResponse | MantleError>;
     /**

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1127,14 +1127,12 @@ declare class MantleClient {
         id: string;
     }): Promise<SuccessResponse | MantleError>;
     /**
-     * Track a CTA click on an engagement (notification, checklist, etc.) as a usage event
-     * @param params.id - The ID of the engagement that was clicked
-     * @param params.engagementType - The type of engagement (e.g. "notification", "checklist")
+     * Track a CTA click on an engagement as a usage event
+     * @param params.id - The ID of the notification (Notify record) that was clicked
      * @returns A promise that resolves to a success response or an error
      */
     trackEngagementCtaClick(params: {
         id: string;
-        engagementType: "notification" | "checklist";
     }): Promise<SuccessResponse | MantleError>;
     /**
      * Update a notification to set the readAt and dismissedAt dates

--- a/dist/index.js
+++ b/dist/index.js
@@ -479,14 +479,14 @@ var MantleClient = class {
     });
   }
   /**
-   * Track a CTA click on an engagement as a usage event
+   * Track a CTA click on a notification as a usage event
    * @param params.id - The ID of the notification (Notify record) that was clicked
    * @returns A promise that resolves to a success response or an error
    */
-  trackEngagementCtaClick(params) {
+  trackNotificationCtaClick(params) {
     return __async(this, null, function* () {
       return yield this.mantleRequest({
-        path: `engagements/${params.id}/cta_click`,
+        path: `notifications/${params.id}/cta_click`,
         method: "POST"
       });
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -479,19 +479,15 @@ var MantleClient = class {
     });
   }
   /**
-   * Track a CTA click on an engagement (notification, checklist, etc.) as a usage event
-   * @param params.id - The ID of the engagement that was clicked
-   * @param params.engagementType - The type of engagement (e.g. "notification", "checklist")
+   * Track a CTA click on an engagement as a usage event
+   * @param params.id - The ID of the notification (Notify record) that was clicked
    * @returns A promise that resolves to a success response or an error
    */
   trackEngagementCtaClick(params) {
     return __async(this, null, function* () {
       return yield this.mantleRequest({
         path: `engagements/${params.id}/cta_click`,
-        method: "POST",
-        body: {
-          engagementType: params.engagementType
-        }
+        method: "POST"
       });
     });
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -479,15 +479,20 @@ var MantleClient = class {
     });
   }
   /**
-   * Track a CTA click on a notification as a usage event
-   * @param params.id - The ID of the notification (Notify record) that was clicked
+   * Track a notification CTA as a usage event
+   * @param params.id - The ID of the notification (Notify record)
+   * @param params.type - The type of CTA interaction. Defaults to "trigger"
    * @returns A promise that resolves to a success response or an error
    */
-  trackNotificationCtaClick(params) {
+  trackNotificationCta(params) {
     return __async(this, null, function* () {
+      var _a;
       return yield this.mantleRequest({
-        path: `notifications/${params.id}/cta_click`,
-        method: "POST"
+        path: `notifications/${params.id}/track`,
+        method: "POST",
+        body: {
+          type: (_a = params.type) != null ? _a : "trigger"
+        }
       });
     });
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -479,6 +479,23 @@ var MantleClient = class {
     });
   }
   /**
+   * Track a CTA click on an engagement (notification, checklist, etc.) as a usage event
+   * @param params.id - The ID of the engagement that was clicked
+   * @param params.engagementType - The type of engagement (e.g. "notification", "checklist")
+   * @returns A promise that resolves to a success response or an error
+   */
+  trackEngagementCtaClick(params) {
+    return __async(this, null, function* () {
+      return yield this.mantleRequest({
+        path: `engagements/${params.id}/cta_click`,
+        method: "POST",
+        body: {
+          engagementType: params.engagementType
+        }
+      });
+    });
+  }
+  /**
    * Update a notification to set the readAt and dismissedAt dates
    * @param params.id - The ID of the notification to update
    * @param params.readAt - The date the notification was read

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -457,6 +457,23 @@ var MantleClient = class {
     });
   }
   /**
+   * Track a CTA click on an engagement (notification, checklist, etc.) as a usage event
+   * @param params.id - The ID of the engagement that was clicked
+   * @param params.engagementType - The type of engagement (e.g. "notification", "checklist")
+   * @returns A promise that resolves to a success response or an error
+   */
+  trackEngagementCtaClick(params) {
+    return __async(this, null, function* () {
+      return yield this.mantleRequest({
+        path: `engagements/${params.id}/cta_click`,
+        method: "POST",
+        body: {
+          engagementType: params.engagementType
+        }
+      });
+    });
+  }
+  /**
    * Update a notification to set the readAt and dismissedAt dates
    * @param params.id - The ID of the notification to update
    * @param params.readAt - The date the notification was read

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -457,19 +457,15 @@ var MantleClient = class {
     });
   }
   /**
-   * Track a CTA click on an engagement (notification, checklist, etc.) as a usage event
-   * @param params.id - The ID of the engagement that was clicked
-   * @param params.engagementType - The type of engagement (e.g. "notification", "checklist")
+   * Track a CTA click on an engagement as a usage event
+   * @param params.id - The ID of the notification (Notify record) that was clicked
    * @returns A promise that resolves to a success response or an error
    */
   trackEngagementCtaClick(params) {
     return __async(this, null, function* () {
       return yield this.mantleRequest({
         path: `engagements/${params.id}/cta_click`,
-        method: "POST",
-        body: {
-          engagementType: params.engagementType
-        }
+        method: "POST"
       });
     });
   }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -457,15 +457,20 @@ var MantleClient = class {
     });
   }
   /**
-   * Track a CTA click on a notification as a usage event
-   * @param params.id - The ID of the notification (Notify record) that was clicked
+   * Track a notification CTA as a usage event
+   * @param params.id - The ID of the notification (Notify record)
+   * @param params.type - The type of CTA interaction. Defaults to "trigger"
    * @returns A promise that resolves to a success response or an error
    */
-  trackNotificationCtaClick(params) {
+  trackNotificationCta(params) {
     return __async(this, null, function* () {
+      var _a;
       return yield this.mantleRequest({
-        path: `notifications/${params.id}/cta_click`,
-        method: "POST"
+        path: `notifications/${params.id}/track`,
+        method: "POST",
+        body: {
+          type: (_a = params.type) != null ? _a : "trigger"
+        }
       });
     });
   }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -457,14 +457,14 @@ var MantleClient = class {
     });
   }
   /**
-   * Track a CTA click on an engagement as a usage event
+   * Track a CTA click on a notification as a usage event
    * @param params.id - The ID of the notification (Notify record) that was clicked
    * @returns A promise that resolves to a success response or an error
    */
-  trackEngagementCtaClick(params) {
+  trackNotificationCtaClick(params) {
     return __async(this, null, function* () {
       return yield this.mantleRequest({
-        path: `engagements/${params.id}/cta_click`,
+        path: `notifications/${params.id}/cta_click`,
         method: "POST"
       });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heymantle/client",
-  "version": "1.1.70",
+  "version": "1.1.71",
   "description": "Mantle API Client for TypeScript and JavaScript",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -36,6 +36,5 @@
     "typescript": "^5.4.3",
     "tsup": "^8.0.2",
     "vitest": "^1.2.0"
-  },
-  "packageManager": "pnpm@10.30.0+sha512.2b5753de015d480eeb88f5b5b61e0051f05b4301808a82ec8b840c9d2adf7748eb352c83f5c1593ca703ff1017295bc3fdd3119abb9686efc96b9fcb18200937"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
     "typescript": "^5.4.3",
     "tsup": "^8.0.2",
     "vitest": "^1.2.0"
-  }
+  },
+  "packageManager": "pnpm@10.30.0+sha512.2b5753de015d480eeb88f5b5b61e0051f05b4301808a82ec8b840c9d2adf7748eb352c83f5c1593ca703ff1017295bc3fdd3119abb9686efc96b9fcb18200937"
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1494,9 +1494,9 @@ describe('MantleClient', () => {
     });
   });
 
-  describe('Engagement CTA tracking', () => {
-    describe('trackEngagementCtaClick', () => {
-      it('should POST to the engagement cta_click endpoint', async () => {
+  describe('Notification CTA tracking', () => {
+    describe('trackNotificationCtaClick', () => {
+      it('should POST to the notification cta_click endpoint', async () => {
         const client = new MantleClient({
           appId: 'test-app-id',
           customerApiToken: 'customer-token',
@@ -1507,12 +1507,12 @@ describe('MantleClient', () => {
           json: async () => ({ success: true }),
         });
 
-        const result = await client.trackEngagementCtaClick({
+        const result = await client.trackNotificationCtaClick({
           id: 'notif-123',
         });
 
         expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('/engagements/notif-123/cta_click'),
+          expect.stringContaining('/notifications/notif-123/cta_click'),
           expect.objectContaining({
             method: 'POST',
           })
@@ -1531,7 +1531,7 @@ describe('MantleClient', () => {
           json: async () => ({ error: 'Notification not found' }),
         });
 
-        const result = await client.trackEngagementCtaClick({
+        const result = await client.trackNotificationCtaClick({
           id: 'nonexistent-id',
         });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1494,6 +1494,83 @@ describe('MantleClient', () => {
     });
   });
 
+  describe('Engagement CTA tracking', () => {
+    describe('trackEngagementCtaClick', () => {
+      it('should track a notification CTA click', async () => {
+        const client = new MantleClient({
+          appId: 'test-app-id',
+          customerApiToken: 'customer-token',
+        });
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true }),
+        });
+
+        const result = await client.trackEngagementCtaClick({
+          id: 'notif-123',
+          engagementType: 'notification',
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/engagements/notif-123/cta_click'),
+          expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ engagementType: 'notification' }),
+          })
+        );
+        expect(result).toEqual({ success: true });
+      });
+
+      it('should track a checklist CTA click', async () => {
+        const client = new MantleClient({
+          appId: 'test-app-id',
+          customerApiToken: 'customer-token',
+        });
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true }),
+        });
+
+        const result = await client.trackEngagementCtaClick({
+          id: 'checklist-456',
+          engagementType: 'checklist',
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/engagements/checklist-456/cta_click'),
+          expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ engagementType: 'checklist' }),
+          })
+        );
+        expect(result).toEqual({ success: true });
+      });
+
+      it('should return error on failure', async () => {
+        const client = new MantleClient({
+          appId: 'test-app-id',
+          customerApiToken: 'customer-token',
+        });
+
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          json: async () => ({ error: 'Invalid engagementType. Must be one of: notification, checklist' }),
+        });
+
+        const result = await client.trackEngagementCtaClick({
+          id: 'notif-123',
+          engagementType: 'notification',
+        });
+
+        expect(result).toEqual({
+          error: 'Invalid engagementType. Must be one of: notification, checklist',
+        });
+      });
+    });
+  });
+
   describe('Checklists', () => {
     describe('getChecklist', () => {
       it('should get checklist by ID', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1496,7 +1496,7 @@ describe('MantleClient', () => {
 
   describe('Engagement CTA tracking', () => {
     describe('trackEngagementCtaClick', () => {
-      it('should track a notification CTA click', async () => {
+      it('should POST to the engagement cta_click endpoint', async () => {
         const client = new MantleClient({
           appId: 'test-app-id',
           customerApiToken: 'customer-token',
@@ -1509,46 +1509,18 @@ describe('MantleClient', () => {
 
         const result = await client.trackEngagementCtaClick({
           id: 'notif-123',
-          engagementType: 'notification',
         });
 
         expect(mockFetch).toHaveBeenCalledWith(
           expect.stringContaining('/engagements/notif-123/cta_click'),
           expect.objectContaining({
             method: 'POST',
-            body: JSON.stringify({ engagementType: 'notification' }),
           })
         );
         expect(result).toEqual({ success: true });
       });
 
-      it('should track a checklist CTA click', async () => {
-        const client = new MantleClient({
-          appId: 'test-app-id',
-          customerApiToken: 'customer-token',
-        });
-
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ success: true }),
-        });
-
-        const result = await client.trackEngagementCtaClick({
-          id: 'checklist-456',
-          engagementType: 'checklist',
-        });
-
-        expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('/engagements/checklist-456/cta_click'),
-          expect.objectContaining({
-            method: 'POST',
-            body: JSON.stringify({ engagementType: 'checklist' }),
-          })
-        );
-        expect(result).toEqual({ success: true });
-      });
-
-      it('should return error on failure', async () => {
+      it('should return error when notification not found', async () => {
         const client = new MantleClient({
           appId: 'test-app-id',
           customerApiToken: 'customer-token',
@@ -1556,16 +1528,15 @@ describe('MantleClient', () => {
 
         mockFetch.mockResolvedValueOnce({
           ok: false,
-          json: async () => ({ error: 'Invalid engagementType. Must be one of: notification, checklist' }),
+          json: async () => ({ error: 'Notification not found' }),
         });
 
         const result = await client.trackEngagementCtaClick({
-          id: 'notif-123',
-          engagementType: 'notification',
+          id: 'nonexistent-id',
         });
 
         expect(result).toEqual({
-          error: 'Invalid engagementType. Must be one of: notification, checklist',
+          error: 'Notification not found',
         });
       });
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1495,8 +1495,8 @@ describe('MantleClient', () => {
   });
 
   describe('Notification CTA tracking', () => {
-    describe('trackNotificationCtaClick', () => {
-      it('should POST to the notification cta_click endpoint', async () => {
+    describe('trackNotificationCta', () => {
+      it('should POST to the notification track endpoint with default type trigger', async () => {
         const client = new MantleClient({
           appId: 'test-app-id',
           customerApiToken: 'customer-token',
@@ -1507,17 +1507,43 @@ describe('MantleClient', () => {
           json: async () => ({ success: true }),
         });
 
-        const result = await client.trackNotificationCtaClick({
+        const result = await client.trackNotificationCta({
           id: 'notif-123',
         });
 
         expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('/notifications/notif-123/cta_click'),
+          expect.stringContaining('/notifications/notif-123/track'),
           expect.objectContaining({
             method: 'POST',
+            body: JSON.stringify({ type: 'trigger' }),
           })
         );
         expect(result).toEqual({ success: true });
+      });
+
+      it('should pass type click when specified', async () => {
+        const client = new MantleClient({
+          appId: 'test-app-id',
+          customerApiToken: 'customer-token',
+        });
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true }),
+        });
+
+        await client.trackNotificationCta({
+          id: 'notif-123',
+          type: 'click',
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/notifications/notif-123/track'),
+          expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ type: 'click' }),
+          })
+        );
       });
 
       it('should return error when notification not found', async () => {
@@ -1531,7 +1557,7 @@ describe('MantleClient', () => {
           json: async () => ({ error: 'Notification not found' }),
         });
 
-        const result = await client.trackNotificationCtaClick({
+        const result = await client.trackNotificationCta({
           id: 'nonexistent-id',
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1489,6 +1489,25 @@ class MantleClient {
   }
 
   /**
+   * Track a CTA click on an engagement (notification, checklist, etc.) as a usage event
+   * @param params.id - The ID of the engagement that was clicked
+   * @param params.engagementType - The type of engagement (e.g. "notification", "checklist")
+   * @returns A promise that resolves to a success response or an error
+   */
+  async trackEngagementCtaClick(params: {
+    id: string;
+    engagementType: "notification" | "checklist";
+  }): Promise<SuccessResponse | MantleError> {
+    return await this.mantleRequest<SuccessResponse>({
+      path: `engagements/${params.id}/cta_click`,
+      method: "POST",
+      body: {
+        engagementType: params.engagementType,
+      },
+    });
+  }
+
+  /**
    * Update a notification to set the readAt and dismissedAt dates
    * @param params.id - The ID of the notification to update
    * @param params.readAt - The date the notification was read

--- a/src/index.ts
+++ b/src/index.ts
@@ -1489,15 +1489,15 @@ class MantleClient {
   }
 
   /**
-   * Track a CTA click on an engagement as a usage event
+   * Track a CTA click on a notification as a usage event
    * @param params.id - The ID of the notification (Notify record) that was clicked
    * @returns A promise that resolves to a success response or an error
    */
-  async trackEngagementCtaClick(params: {
+  async trackNotificationCtaClick(params: {
     id: string;
   }): Promise<SuccessResponse | MantleError> {
     return await this.mantleRequest<SuccessResponse>({
-      path: `engagements/${params.id}/cta_click`,
+      path: `notifications/${params.id}/cta_click`,
       method: "POST",
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1489,21 +1489,16 @@ class MantleClient {
   }
 
   /**
-   * Track a CTA click on an engagement (notification, checklist, etc.) as a usage event
-   * @param params.id - The ID of the engagement that was clicked
-   * @param params.engagementType - The type of engagement (e.g. "notification", "checklist")
+   * Track a CTA click on an engagement as a usage event
+   * @param params.id - The ID of the notification (Notify record) that was clicked
    * @returns A promise that resolves to a success response or an error
    */
   async trackEngagementCtaClick(params: {
     id: string;
-    engagementType: "notification" | "checklist";
   }): Promise<SuccessResponse | MantleError> {
     return await this.mantleRequest<SuccessResponse>({
       path: `engagements/${params.id}/cta_click`,
       method: "POST",
-      body: {
-        engagementType: params.engagementType,
-      },
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1011,7 +1011,7 @@ class MantleClient {
     }
     if (typeof window !== "undefined" && apiKey) {
       throw new Error(
-        "MantleClient apiKey should never be used in the browser"
+        "MantleClient apiKey should never be used in the browser",
       );
     }
 
@@ -1112,7 +1112,7 @@ class MantleClient {
    * @returns A promise that resolves to an object with the customer API token or an error
    */
   async identify(
-    params: ShopifyIdentifyParams | OtherPlatformIdentifyParams
+    params: ShopifyIdentifyParams | OtherPlatformIdentifyParams,
   ): Promise<IdentifyResponse | MantleError> {
     return await this.mantleRequest<IdentifyResponse>({
       path: "identify",
@@ -1233,7 +1233,7 @@ class MantleClient {
       | ({
           planId?: never;
           planIds: string[];
-        } & Omit<SubscribeParams, "planId" | "planIds">)
+        } & Omit<SubscribeParams, "planId" | "planIds">),
   ): Promise<Subscription | MantleError> {
     return await this.mantleRequest<Subscription>({
       path: "subscriptions",
@@ -1383,7 +1383,7 @@ class MantleClient {
    * @returns A promise that resolves to the list of invoices or an error
    */
   async listInvoices(
-    params: ListInvoicesParams = {}
+    params: ListInvoicesParams = {},
   ): Promise<ListInvoicesResponse | MantleError> {
     return await this.mantleRequest<ListInvoicesResponse>({
       path: "invoices",
@@ -1489,16 +1489,21 @@ class MantleClient {
   }
 
   /**
-   * Track a CTA click on a notification as a usage event
-   * @param params.id - The ID of the notification (Notify record) that was clicked
+   * Track a notification CTA as a usage event
+   * @param params.id - The ID of the notification (Notify record)
+   * @param params.type - The type of CTA interaction. Defaults to "trigger"
    * @returns A promise that resolves to a success response or an error
    */
-  async trackNotificationCtaClick(params: {
+  async trackNotificationCta(params: {
     id: string;
+    type?: "trigger" | "click";
   }): Promise<SuccessResponse | MantleError> {
     return await this.mantleRequest<SuccessResponse>({
-      path: `notifications/${params.id}/cta_click`,
+      path: `notifications/${params.id}/track`,
       method: "POST",
+      body: {
+        type: params.type ?? "trigger",
+      },
     });
   }
 
@@ -1530,7 +1535,7 @@ class MantleClient {
    * @returns A promise that resolves to the checklist, or null if no checklist is found, or an error
    */
   async getChecklist(
-    idOrHandle: string
+    idOrHandle: string,
   ): Promise<Checklist | null | MantleError> {
     return await this.mantleRequest<Checklist | null>({
       path: `checklists/${idOrHandle}`,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a single new client method and tests without changing existing request/notification behavior; risk is limited to the new endpoint contract and payload shape.
> 
> **Overview**
> Adds a new `MantleClient.trackEngagementCtaClick` API to record engagement CTA clicks (currently `notification` or `checklist`) by POSTing to `engagements/:id/cta_click` with an `engagementType` payload.
> 
> Updates the published `dist` JS/TS artifacts and adds Vitest coverage for success cases and error passthrough behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 166f3c5712bd80d557b270a9a72fed5c0ad89ea5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->